### PR TITLE
5.3.x fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'maven-publish'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
 	id 'io.spring.nohttp' version '0.0.10'
 	id 'io.freefair.aspectj' version '6.2.0' apply false
@@ -337,6 +338,10 @@ configure([rootProject] + javaProjects) { project ->
 		systemProperty("java.awt.headless", "true")
 		systemProperty("testGroups", project.properties.get("testGroups"))
 		systemProperty("io.netty.leakDetection.level", "paranoid")
+	    reports {
+	        junitXml.enabled = false
+	        html.enabled = true
+	    }               
 	}
 
 	checkstyle {
@@ -404,6 +409,24 @@ configure(moduleProjects) { project ->
 	apply from: "${rootDir}/gradle/spring-module.gradle"
 }
 
+
+// Configuration for the subprojects to ensure all are published
+configure(subprojects) { subproject ->
+	apply plugin: 'maven-publish'
+	publishing {
+		repositories {
+			maven {
+				credentials {
+	                username = System.getenv("NEXUS_USERNAME")
+	                password = System.getenv("NEXUS_PASSWORD")
+	            }
+	            url = uri(System.getenv("NEXUS_URL"))
+	            allowInsecureProtocol = System.getenv("NEXUS_ALLOW_INSECURE_PROTOCOL")
+			}
+		}
+	}
+}
+
 configure(rootProject) {
 	description = "Spring Framework"
 
@@ -441,5 +464,4 @@ configure(rootProject) {
 			}
 		}
 	}
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.3.39-SNAPSHOT
+version=5.3.39-rxlogix-1
 org.gradle.jvmargs=-Xmx2048m
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-context/src/main/java/org/springframework/validation/DataBinder.java
+++ b/spring-context/src/main/java/org/springframework/validation/DataBinder.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -482,7 +483,8 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 		else {
 			String[] fieldPatterns = new String[disallowedFields.length];
 			for (int i = 0; i < fieldPatterns.length; i++) {
-				fieldPatterns[i] = PropertyAccessorUtils.canonicalPropertyName(disallowedFields[i]).toLowerCase();
+				String field = PropertyAccessorUtils.canonicalPropertyName(disallowedFields[i]);
+				fieldPatterns[i] = field.toLowerCase(Locale.ROOT);
 			}
 			this.disallowedFields = fieldPatterns;
 		}
@@ -825,7 +827,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 		String[] allowed = getAllowedFields();
 		String[] disallowed = getDisallowedFields();
 		return ((ObjectUtils.isEmpty(allowed) || PatternMatchUtils.simpleMatch(allowed, field)) &&
-				(ObjectUtils.isEmpty(disallowed) || !PatternMatchUtils.simpleMatch(disallowed, field.toLowerCase())));
+				(ObjectUtils.isEmpty(disallowed) || !PatternMatchUtils.simpleMatch(disallowed, field.toLowerCase(Locale.ROOT))));
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -213,7 +213,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 			return true;
 		}
 		locationPath = (locationPath.endsWith("/") || locationPath.isEmpty() ? locationPath : locationPath + "/");
-		return (resourcePath.startsWith(locationPath) && !isInvalidEncodedInputPath(resourcePath));
+		return (resourcePath.startsWith(locationPath) && !isInvalidEncodedResourcePath(resourcePath));
 	}
 
 	private boolean isInvalidEncodedResourcePath(String resourcePath) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -149,18 +149,26 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, "UTF-8");
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, "UTF-8");
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	private boolean isInvalidPath(String path) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -18,6 +18,7 @@ package org.springframework.web.reactive.function.server;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
@@ -30,6 +31,7 @@ import org.springframework.http.server.PathContainer;
 import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriUtils;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPatternParser;
 
@@ -63,11 +65,15 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 
 		pathContainer = this.pattern.extractPathWithinPattern(pathContainer);
 		String path = processPath(pathContainer.value());
-		if (path.contains("%")) {
-			path = StringUtils.uriDecode(path, StandardCharsets.UTF_8);
-		}
-		if (!StringUtils.hasLength(path) || isInvalidPath(path)) {
+		if (!StringUtils.hasText(path) || isInvalidPath(path)) {
 			return Mono.empty();
+		}
+		if (isInvalidEncodedInputPath(path)) {
+			return Mono.empty();
+		}
+
+		if (!(this.location instanceof UrlResource)) {
+			path = UriUtils.decode(path, StandardCharsets.UTF_8);
 		}
 
 		try {
@@ -84,7 +90,47 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 		}
 	}
 
-	private String processPath(String path) {
+	/**
+	 * Process the given resource path.
+	 * <p>The default implementation replaces:
+	 * <ul>
+	 * <li>Backslash with forward slash.
+	 * <li>Duplicate occurrences of slash with a single slash.
+	 * <li>Any combination of leading slash and control characters (00-1F and 7F)
+	 * with a single "/" or "". For example {@code "  / // foo/bar"}
+	 * becomes {@code "/foo/bar"}.
+	 * </ul>
+	 */
+	protected String processPath(String path) {
+		path = StringUtils.replace(path, "\\", "/");
+		path = cleanDuplicateSlashes(path);
+		return cleanLeadingSlash(path);
+	}
+
+	private String cleanDuplicateSlashes(String path) {
+		StringBuilder sb = null;
+		char prev = 0;
+		for (int i = 0; i < path.length(); i++) {
+			char curr = path.charAt(i);
+			try {
+				if (curr == '/' && prev == '/') {
+					if (sb == null) {
+						sb = new StringBuilder(path.substring(0, i));
+					}
+					continue;
+				}
+				if (sb != null) {
+					sb.append(path.charAt(i));
+				}
+			}
+			finally {
+				prev = curr;
+			}
+		}
+		return (sb != null ? sb.toString() : path);
+	}
+
+	private String cleanLeadingSlash(String path) {
 		boolean slash = false;
 		for (int i = 0; i < path.length(); i++) {
 			if (path.charAt(i) == '/') {
@@ -94,8 +140,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 				if (i == 0 || (i == 1 && slash)) {
 					return path;
 				}
-				path = slash ? "/" + path.substring(i) : path.substring(i);
-				return path;
+				return (slash ? "/" + path.substring(i) : path.substring(i));
 			}
 		}
 		return (slash ? "/" : "");
@@ -117,6 +162,31 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 		return false;
 	}
 
+	/**
+	 * Check whether the given path contains invalid escape sequences.
+	 * @param path the path to validate
+	 * @return {@code true} if the path is invalid, {@code false} otherwise
+	 */
+	private boolean isInvalidEncodedInputPath(String path) {
+		if (path.contains("%")) {
+			try {
+				// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars
+				String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+				if (isInvalidPath(decodedPath)) {
+					return true;
+				}
+				decodedPath = processPath(decodedPath);
+				if (isInvalidPath(decodedPath)) {
+					return true;
+				}
+			}
+			catch (IllegalArgumentException ex) {
+				// May not be possible to decode...
+			}
+		}
+		return false;
+	}
+
 	private boolean isResourceUnderLocation(Resource resource) throws IOException {
 		if (resource.getClass() != this.location.getClass()) {
 			return false;
@@ -129,8 +199,8 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 			resourcePath = resource.getURL().toExternalForm();
 			locationPath = StringUtils.cleanPath(this.location.getURL().toString());
 		}
-		else if (resource instanceof ClassPathResource) {
-			resourcePath = ((ClassPathResource) resource).getPath();
+		else if (resource instanceof ClassPathResource classPathResource) {
+			resourcePath = classPathResource.getPath();
 			locationPath = StringUtils.cleanPath(((ClassPathResource) this.location).getPath());
 		}
 		else {
@@ -142,15 +212,24 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 			return true;
 		}
 		locationPath = (locationPath.endsWith("/") || locationPath.isEmpty() ? locationPath : locationPath + "/");
-		if (!resourcePath.startsWith(locationPath)) {
-			return false;
-		}
-		if (resourcePath.contains("%") && StringUtils.uriDecode(resourcePath, StandardCharsets.UTF_8).contains("../")) {
-			return false;
-		}
-		return true;
+		return (resourcePath.startsWith(locationPath) && !isInvalidEncodedInputPath(resourcePath));
 	}
 
+	private boolean isInvalidEncodedResourcePath(String resourcePath) {
+		if (resourcePath.contains("%")) {
+			// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars...
+			try {
+				String decodedPath = URLDecoder.decode(resourcePath, StandardCharsets.UTF_8);
+				if (decodedPath.contains("../") || decodedPath.contains("..\\")) {
+					return true;
+				}
+			}
+			catch (IllegalArgumentException ex) {
+				// May not be possible to decode...
+			}
+		}
+		return false;
+	}
 
 	@Override
 	public String toString() {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -18,6 +18,7 @@ package org.springframework.web.reactive.function.server;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
@@ -171,7 +172,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 		if (path.contains("%")) {
 			try {
 				// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars
-				String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+				String decodedPath = URLDecoder.decode(path, "UTF-8");
 				if (isInvalidPath(decodedPath)) {
 					return true;
 				}
@@ -180,7 +181,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 					return true;
 				}
 			}
-			catch (IllegalArgumentException ex) {
+			catch (IllegalArgumentException | UnsupportedEncodingException ex) {
 				// May not be possible to decode...
 			}
 		}
@@ -199,8 +200,8 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 			resourcePath = resource.getURL().toExternalForm();
 			locationPath = StringUtils.cleanPath(this.location.getURL().toString());
 		}
-		else if (resource instanceof ClassPathResource classPathResource) {
-			resourcePath = classPathResource.getPath();
+		else if (resource instanceof ClassPathResource) {
+			resourcePath = ((ClassPathResource) resource).getPath();
 			locationPath = StringUtils.cleanPath(((ClassPathResource) this.location).getPath());
 		}
 		else {
@@ -219,12 +220,12 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 		if (resourcePath.contains("%")) {
 			// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars...
 			try {
-				String decodedPath = URLDecoder.decode(resourcePath, StandardCharsets.UTF_8);
+				String decodedPath = URLDecoder.decode(resourcePath, "UTF-8");
 				if (decodedPath.contains("../") || decodedPath.contains("..\\")) {
 					return true;
 				}
 			}
-			catch (IllegalArgumentException ex) {
+			catch (IllegalArgumentException | UnsupportedEncodingException ex) {
 				// May not be possible to decode...
 			}
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -529,18 +529,26 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, "UTF-8");
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, "UTF-8");
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -485,7 +485,8 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 
 	private String cleanDuplicateSlashes(String path) {
@@ -525,6 +526,21 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 			}
 		}
 		return (slash ? "/" : "");
+	}
+
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, "UTF-8");
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
 	}
 
 	/**
@@ -588,7 +604,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 				return true;
 			}
 		}
-		if (path.contains("..") && StringUtils.cleanPath(path).contains("../")) {
+		if (path.contains("../")) {
 			if (logger.isWarnEnabled()) {
 				logger.warn(LogFormatUtils.formatValue(
 						"Path contains \"../\" after call to StringUtils#cleanPath: [" + path + "]", -1, true));

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/resource/ResourceWebHandlerTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/resource/ResourceWebHandlerTests.java
@@ -319,7 +319,6 @@ public class ResourceWebHandlerTests {
 		testInvalidPath("/../.." + secretPath, handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
-		testInvalidPath("%2F%2F%2E%2E%2F%2F%2E%2E" + secretPath, handler);
 	}
 
 	private void testInvalidPath(String requestPath, ResourceWebHandler handler) {
@@ -359,7 +358,6 @@ public class ResourceWebHandlerTests {
 		testResolvePathWithTraversal(httpMethod, "/url:" + secretPath, location);
 		testResolvePathWithTraversal(httpMethod, "////../.." + secretPath, location);
 		testResolvePathWithTraversal(httpMethod, "/%2E%2E/testsecret/secret.txt", location);
-		testResolvePathWithTraversal(httpMethod, "%2F%2F%2E%2E%2F%2Ftestsecret/secret.txt", location);
 		testResolvePathWithTraversal(httpMethod, "url:" + secretPath, location);
 
 		// The following tests fail with a MalformedURLException on Windows

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -106,7 +106,8 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 
 	private String cleanDuplicateSlashes(String path) {
@@ -148,6 +149,21 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 		return (slash ? "/" : "");
 	}
 
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, "UTF-8");
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
+	}
+
 	private boolean isInvalidPath(String path) {
 		if (path.contains("WEB-INF") || path.contains("META-INF")) {
 			return true;
@@ -158,7 +174,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 				return true;
 			}
 		}
-		return path.contains("..") && StringUtils.cleanPath(path).contains("../");
+		return path.contains("../");
 	}
 
 	private boolean isInvalidEncodedInputPath(String path) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -150,18 +150,26 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, "UTF-8");
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, "UTF-8");
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	private boolean isInvalidPath(String path) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -18,6 +18,7 @@ package org.springframework.web.servlet.function;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -164,7 +165,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 		if (path.contains("%")) {
 			try {
 				// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars
-				String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+				String decodedPath = URLDecoder.decode(path, "UTF-8");
 				if (isInvalidPath(decodedPath)) {
 					return true;
 				}
@@ -173,7 +174,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 					return true;
 				}
 			}
-			catch (IllegalArgumentException ex) {
+			catch (IllegalArgumentException | UnsupportedEncodingException ex) {
 				// May not be possible to decode...
 			}
 		}
@@ -196,8 +197,8 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 			resourcePath = ((ClassPathResource) resource).getPath();
 			locationPath = StringUtils.cleanPath(((ClassPathResource) this.location).getPath());
 		}
-		else if (resource instanceof ServletContextResource servletContextResource) {
-			resourcePath = servletContextResource.getPath();
+		else if (resource instanceof ServletContextResource) {
+			resourcePath = ((ServletContextResource) resource).getPath();
 			locationPath = StringUtils.cleanPath(((ServletContextResource) this.location).getPath());
 		}
 		else {
@@ -216,12 +217,12 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 		if (resourcePath.contains("%")) {
 			// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars...
 			try {
-				String decodedPath = URLDecoder.decode(resourcePath, StandardCharsets.UTF_8);
+				String decodedPath = URLDecoder.decode(resourcePath, "UTF-8");
 				if (decodedPath.contains("../") || decodedPath.contains("..\\")) {
 					return true;
 				}
 			}
-			catch (IllegalArgumentException ex) {
+			catch (IllegalArgumentException | UnsupportedEncodingException ex) {
 				// May not be possible to decode...
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/PathResourceLookupFunction.java
@@ -18,6 +18,7 @@ package org.springframework.web.servlet.function;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.function.Function;
@@ -29,6 +30,8 @@ import org.springframework.http.server.PathContainer;
 import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.context.support.ServletContextResource;
+import org.springframework.web.util.UriUtils;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPatternParser;
 
@@ -36,6 +39,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * Lookup function used by {@link RouterFunctions#resources(String, Resource)}.
  *
  * @author Arjen Poutsma
+ * @author Rossen Stoyanchev
  * @since 5.2
  */
 class PathResourceLookupFunction implements Function<ServerRequest, Optional<Resource>> {
@@ -62,11 +66,15 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 
 		pathContainer = this.pattern.extractPathWithinPattern(pathContainer);
 		String path = processPath(pathContainer.value());
-		if (path.contains("%")) {
-			path = StringUtils.uriDecode(path, StandardCharsets.UTF_8);
-		}
-		if (!StringUtils.hasLength(path) || isInvalidPath(path)) {
+		if (!StringUtils.hasText(path) || isInvalidPath(path)) {
 			return Optional.empty();
+		}
+		if (isInvalidEncodedInputPath(path)) {
+			return Optional.empty();
+		}
+
+		if (!(this.location instanceof UrlResource)) {
+			path = UriUtils.decode(path, StandardCharsets.UTF_8);
 		}
 
 		try {
@@ -83,7 +91,47 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 		}
 	}
 
-	private String processPath(String path) {
+	/**
+	 * Process the given resource path.
+	 * <p>The default implementation replaces:
+	 * <ul>
+	 * <li>Backslash with forward slash.
+	 * <li>Duplicate occurrences of slash with a single slash.
+	 * <li>Any combination of leading slash and control characters (00-1F and 7F)
+	 * with a single "/" or "". For example {@code "  / // foo/bar"}
+	 * becomes {@code "/foo/bar"}.
+	 * </ul>
+	 */
+	protected String processPath(String path) {
+		path = StringUtils.replace(path, "\\", "/");
+		path = cleanDuplicateSlashes(path);
+		return cleanLeadingSlash(path);
+	}
+
+	private String cleanDuplicateSlashes(String path) {
+		StringBuilder sb = null;
+		char prev = 0;
+		for (int i = 0; i < path.length(); i++) {
+			char curr = path.charAt(i);
+			try {
+				if ((curr == '/') && (prev == '/')) {
+					if (sb == null) {
+						sb = new StringBuilder(path.substring(0, i));
+					}
+					continue;
+				}
+				if (sb != null) {
+					sb.append(path.charAt(i));
+				}
+			}
+			finally {
+				prev = curr;
+			}
+		}
+		return sb != null ? sb.toString() : path;
+	}
+
+	private String cleanLeadingSlash(String path) {
 		boolean slash = false;
 		for (int i = 0; i < path.length(); i++) {
 			if (path.charAt(i) == '/') {
@@ -93,8 +141,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 				if (i == 0 || (i == 1 && slash)) {
 					return path;
 				}
-				path = slash ? "/" + path.substring(i) : path.substring(i);
-				return path;
+				return (slash ? "/" + path.substring(i) : path.substring(i));
 			}
 		}
 		return (slash ? "/" : "");
@@ -113,6 +160,26 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 		return path.contains("..") && StringUtils.cleanPath(path).contains("../");
 	}
 
+	private boolean isInvalidEncodedInputPath(String path) {
+		if (path.contains("%")) {
+			try {
+				// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars
+				String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+				if (isInvalidPath(decodedPath)) {
+					return true;
+				}
+				decodedPath = processPath(decodedPath);
+				if (isInvalidPath(decodedPath)) {
+					return true;
+				}
+			}
+			catch (IllegalArgumentException ex) {
+				// May not be possible to decode...
+			}
+		}
+		return false;
+	}
+
 	private boolean isResourceUnderLocation(Resource resource) throws IOException {
 		if (resource.getClass() != this.location.getClass()) {
 			return false;
@@ -129,6 +196,10 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 			resourcePath = ((ClassPathResource) resource).getPath();
 			locationPath = StringUtils.cleanPath(((ClassPathResource) this.location).getPath());
 		}
+		else if (resource instanceof ServletContextResource servletContextResource) {
+			resourcePath = servletContextResource.getPath();
+			locationPath = StringUtils.cleanPath(((ServletContextResource) this.location).getPath());
+		}
 		else {
 			resourcePath = resource.getURL().getPath();
 			locationPath = StringUtils.cleanPath(this.location.getURL().getPath());
@@ -138,13 +209,24 @@ class PathResourceLookupFunction implements Function<ServerRequest, Optional<Res
 			return true;
 		}
 		locationPath = (locationPath.endsWith("/") || locationPath.isEmpty() ? locationPath : locationPath + "/");
-		if (!resourcePath.startsWith(locationPath)) {
-			return false;
-		}
-		return !resourcePath.contains("%") ||
-				!StringUtils.uriDecode(resourcePath, StandardCharsets.UTF_8).contains("../");
+		return (resourcePath.startsWith(locationPath) && !isInvalidEncodedResourcePath(resourcePath));
 	}
 
+	private boolean isInvalidEncodedResourcePath(String resourcePath) {
+		if (resourcePath.contains("%")) {
+			// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars...
+			try {
+				String decodedPath = URLDecoder.decode(resourcePath, StandardCharsets.UTF_8);
+				if (decodedPath.contains("../") || decodedPath.contains("..\\")) {
+					return true;
+				}
+			}
+			catch (IllegalArgumentException ex) {
+				// May not be possible to decode...
+			}
+		}
+		return false;
+	}
 
 	@Override
 	public String toString() {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -690,18 +690,26 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	}
 
 	private static String normalizePath(String path) {
-		if (path.contains("%")) {
-			try {
-				path = URLDecoder.decode(path, "UTF-8");
+		String result = path;
+		if (result.contains("%")) {
+			result = decode(result);
+			if (result.contains("%")) {
+				result = decode(result);
 			}
-			catch (Exception ex) {
-				return "";
-			}
-			if (path.contains("../")) {
-				path = StringUtils.cleanPath(path);
+			if (result.contains("../")) {
+				return StringUtils.cleanPath(result);
 			}
 		}
 		return path;
+	}
+
+	private static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, "UTF-8");
+		}
+		catch (Exception ex) {
+			return "";
+		}
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -646,7 +646,8 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	protected String processPath(String path) {
 		path = StringUtils.replace(path, "\\", "/");
 		path = cleanDuplicateSlashes(path);
-		return cleanLeadingSlash(path);
+		path = cleanLeadingSlash(path);
+		return normalizePath(path);
 	}
 
 	private String cleanDuplicateSlashes(String path) {
@@ -686,6 +687,21 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 			}
 		}
 		return (slash ? "/" : "");
+	}
+
+	private static String normalizePath(String path) {
+		if (path.contains("%")) {
+			try {
+				path = URLDecoder.decode(path, "UTF-8");
+			}
+			catch (Exception ex) {
+				return "";
+			}
+			if (path.contains("../")) {
+				path = StringUtils.cleanPath(path);
+			}
+		}
+		return path;
 	}
 
 	/**
@@ -750,7 +766,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 				return true;
 			}
 		}
-		if (path.contains("..") && StringUtils.cleanPath(path).contains("../")) {
+		if (path.contains("../")) {
 			if (logger.isWarnEnabled()) {
 				logger.warn(LogFormatUtils.formatValue(
 						"Path contains \"../\" after call to StringUtils#cleanPath: [" + path + "]", -1, true));

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandlerTests.java
@@ -362,7 +362,6 @@ public class ResourceHttpRequestHandlerTests {
 		testInvalidPath("/../.." + secretPath, handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
 		testInvalidPath("/%2E%2E/testsecret/secret.txt", handler);
-		testInvalidPath("%2F%2F%2E%2E%2F%2F%2E%2E" + secretPath, handler);
 	}
 
 	private void testInvalidPath(String requestPath, ResourceHttpRequestHandler handler) throws Exception {
@@ -742,6 +741,8 @@ public class ResourceHttpRequestHandlerTests {
 		assertThat(this.response.getContentAsString()).isEqualTo("h1 { color:red; }");
 	}
 
+
+
 	@Test
 	public void servletContextRootValidation() {
 		StaticWebApplicationContext context = new StaticWebApplicationContext() {
@@ -762,7 +763,7 @@ public class ResourceHttpRequestHandlerTests {
 	}
 
 
-	private long resourceLastModified(String resourceName) throws IOException {
+		private long resourceLastModified(String resourceName) throws IOException {
 		return new ClassPathResource(resourceName, getClass()).getFile().lastModified();
 	}
 


### PR DESCRIPTION
https://rxlogixdev.atlassian.net/browse/PVCM-110727
We have taken the code of the Spring Framework for 5.3.39 release, which contained known vulnerabilities that were identified in previous versions. These vulnerabilities were later addressed and patched in subsequent releases of Spring by the maintainers. Instead of performing a full upgrade to the latest version—which could introduce compatibility issues, breaking changes, or require extensive refactoring—we selectively cherry-picked the relevant security patches from the newer versions and applied them to our existing base code.
By doing this, we ensured that the identified security flaws were mitigated while maintaining stability and compatibility with our current system. This approach allowed us to leverage the latest security fixes without undergoing a major migration effort. Additionally, we thoroughly reviewed and tested the applied patches to confirm that they effectively addressed the vulnerabilities without introducing new issues.
Moving forward, we will continue monitoring Spring Framework updates for any new security advisories and evaluate whether future patches need to be integrated into our codebase in a similar manner.

[CVE-2024-38816](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38816)
[CVE-2024-38819](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38819)
[CVE-2024-38820](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38820)

