### PR TITLE
PVR-90845 Fix CVE-2024-38828: DoS via Spring MVC controller method with byte[] parameter vulnerability reported by snyk

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.3.39-rxlogix-1
+version=5.3.39-rxlogix-2
 org.gradle.jvmargs=-Xmx2048m
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -52,12 +52,11 @@ public class ByteArrayHttpMessageConverter extends AbstractHttpMessageConverter<
 	}
 
 	@Override
-	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage inputMessage) throws IOException {
-		long contentLength = inputMessage.getHeaders().getContentLength();
-		ByteArrayOutputStream bos =
-				new ByteArrayOutputStream(contentLength >= 0 ? (int) contentLength : StreamUtils.BUFFER_SIZE);
-		StreamUtils.copy(inputMessage.getBody(), bos);
-		return bos.toByteArray();
+	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage message) throws IOException {
+		long length = message.getHeaders().getContentLength();
+		return (length >= 0 && length < Integer.MAX_VALUE ?
+				message.getBody().readNBytes((int) length) :
+				message.getBody().readAllBytes());
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -52,11 +52,17 @@ public class ByteArrayHttpMessageConverter extends AbstractHttpMessageConverter<
 	}
 
 	@Override
-	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage message) throws IOException {
-		long length = message.getHeaders().getContentLength();
-		return (length >= 0 && length < Integer.MAX_VALUE ?
-				message.getBody().readNBytes((int) length) :
-				message.getBody().readAllBytes());
+	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage inputMessage) throws IOException {
+		long contentLength = inputMessage.getHeaders().getContentLength();
+		ByteArrayOutputStream bos =
+				new ByteArrayOutputStream(contentLength >= 0 ? (int) contentLength : StreamUtils.BUFFER_SIZE);
+		if(contentLength >= 0 && contentLength < Integer.MAX_VALUE) {
+			StreamUtils.copyRange(inputMessage.getBody(), bos, 0, (int) contentLength - 1 );
+		}
+		else {
+			StreamUtils.copy(inputMessage.getBody(), bos);
+		}
+		return bos.toByteArray();
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/http/converter/ByteArrayHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ByteArrayHttpMessageConverterTests.java
@@ -58,6 +58,16 @@ public class ByteArrayHttpMessageConverterTests {
 	}
 
 	@Test
+	public void readWithContentLengthHeaderSet() throws IOException {
+		byte[] body = new byte[]{0x1, 0x2, 0x3, 0x4, 0x5};
+		MockHttpInputMessage inputMessage = new MockHttpInputMessage(body);
+		inputMessage.getHeaders().setContentType(new MediaType("application", "octet-stream"));
+		inputMessage.getHeaders().setContentLength(body.length);
+		byte[] result = converter.read(byte[].class, inputMessage);
+		assertThat(result).as("Invalid result").isEqualTo(body);
+	}
+
+	@Test
 	public void write() throws IOException {
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		byte[] body = new byte[]{0x1, 0x2};


### PR DESCRIPTION
We have taken the source code of the Spring Framework from the 5.3.39 release, which contained a known vulnerability related to unbounded input stream handling (CVE-2024-38828). This vulnerability was addressed in newer Spring Framework versions by the maintainers. However, instead of upgrading the entire framework to the latest major version (which could introduce breaking changes or require extensive regression testing), we selectively backported the relevant fix into our codebase.

Specifically, we updated the ByteArrayHttpMessageConverter to mirror the safer implementation introduced in Spring Framework 6.0, which ensures that the number of bytes read from the HTTP request body is strictly bounded by the Content-Length header. This mitigates the risk of memory exhaustion or denial-of-service attacks from large or chunked payloads.

This fix is included in our patched release: Spring 5.3.39-rxlogix-2, which has been tested and verified for compatibility with the RxLogix platform. 

By taking this targeted patching approach, we ensured security hardening without compromising system stability or undergoing a major migration. We will continue to track official Spring advisories and backport further fixes as needed to maintain a secure and stable codebase.

Included CVEs:

CVE-2024-38828